### PR TITLE
[WFLY-13772] : Upgrade to Netty 4.1.50.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
         <version.httpunit>1.7.2</version.httpunit>
         <version.io.agroal>1.3</version.io.agroal>
         <version.io.jaegertracing>0.34.3</version.io.jaegertracing>
-        <version.io.netty>4.1.48.Final</version.io.netty>
+        <version.io.netty>4.1.51.Final</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.2.1</version.io.opentracing.concurrent>
         <version.io.opentracing.interceptors>0.0.4</version.io.opentracing.interceptors>


### PR DESCRIPTION
Upgrade Netty to its latest version 4.1.50.Final which includes both security fixes and AArch64 performance improvements.
Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html

Jira: https://issues.redhat.com/browse/WFLY-13772